### PR TITLE
Fix stuck goroutine on disconnect

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -64,6 +64,7 @@ func (c *connection) OnData(m *message) error {
 
 func (c *connection) Close() error {
 	c.session.closeConnection(c.connID, io.EOF)
+	c.backPressure.Close()
 	return nil
 }
 


### PR DESCRIPTION
If the tunnel client is current blocked on backPressure.Wait() when the
websocket tunnel is terminated it will leak a goroutine as nothing will
ever notify backPressure.Wait() to stop waiting.
